### PR TITLE
Updated _boilerplate html template path

### DIFF
--- a/root/js/build/modules/_boilerplate/module.js
+++ b/root/js/build/modules/_boilerplate/module.js
@@ -1,1 +1,1 @@
-define(["jquery","underscore","backbone","text!modules/_boilerplate/templates/app.html"],function(e,t,n,r){var i=n.View.extend({events:{},initialize:function(){t.bindAll(this)},render:function(){return this.$el.html(t.template(r,{})),this}});return i});
+define(["jquery","underscore","backbone","text!modules/_boilerplate/templates/module.html"],function(e,t,n,r){var i=n.View.extend({events:{},initialize:function(){t.bindAll(this)},render:function(){return this.$el.html(t.template(r,{})),this}});return i});

--- a/root/js/dev/modules/_boilerplate/module.js
+++ b/root/js/dev/modules/_boilerplate/module.js
@@ -2,7 +2,7 @@ define([
     '{%= $ %}',
     'underscore',
     'backbone',
-    'text!modules/_boilerplate/templates/app.html'
+    'text!modules/_boilerplate/templates/module.html'
 ], function ($, _, Backbone, Template) {
 
     var View = Backbone.View.extend({


### PR DESCRIPTION
Just a quick fix for the html template path in the _boilerplate. Html template pointed app.html rather then module.html.
